### PR TITLE
fixed bug with self.title being used before assignment in PlayerState

### DIFF
--- a/lastfm_mpris2_scrobbler/PlayerState.py
+++ b/lastfm_mpris2_scrobbler/PlayerState.py
@@ -6,6 +6,7 @@ class PlayerState:
         self.total_played_time = 0
         self.last_observation_timestamp = get_unix_timestamp()
         self.trackid = ""
+        self.title = ""
         self.if_scrobbled = False
         if metadata_dict is not None:
             self.update_status(metadata_dict, playback_status, self.last_observation_timestamp)


### PR DESCRIPTION
Noticed that `self.title` was being used in `update_status` in the `PlayerState` class before assignment, which led to it crashing when title wasn't previously set. This should fix it, although ideally you'd declare all variables before using them/assigning them. It's good practice to declare all variables in `__init__` (from what I know, I don't code _that_ much).